### PR TITLE
housekeeping: Update to mention Verify base packages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ public static class HelloWorld
 
 Can be tested as follows:
 
-This assumes that you are using the XUnit Verify adapter, change the `using VerifyXUnit` if using other testing frameworks.
+This snippets assumes use of the XUnit Verify adapter, change the `using VerifyXUnit` if using other testing frameworks.
 
 <!-- snippet: SampleTest.cs -->
 <a id='snippet-SampleTest.cs'></a>

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,8 @@ public static class HelloWorld
 
 Can be tested as follows:
 
+This assumes that you are using the XUnit Verify adapter, change the `using VerifyXUnit` if using other testing frameworks.
+
 <!-- snippet: SampleTest.cs -->
 <a id='snippet-SampleTest.cs'></a>
 ```cs

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Part of the <a href='https://dotnetfoundation.org' alt=''>.NET Foundation</a>
 
 https://nuget.org/packages/Verify.SourceGenerators/
 
+Install one of the Verify [testing framework adapters](https://github.com/verifytests/verify#nuget-packages) NuGet packages.
 
 ## Initialize
 


### PR DESCRIPTION
This addresses the documentation issue mentioned in https://github.com/VerifyTests/Verify.SourceGenerators/issues/15

Makes it clearer to the user that the Verify adapters are a core dependency of the Verify Source Generators, and that users will need to include at least one.