### PR TITLE
Fix diagnostic message not included in snapshots

### DIFF
--- a/src/SampleGenerator/HelloWorldGenerator.cs
+++ b/src/SampleGenerator/HelloWorldGenerator.cs
@@ -21,7 +21,7 @@ public static class HelloWorld
         var descriptor = new DiagnosticDescriptor(
             id: "theId",
             title: "the title",
-            messageFormat: "the descriptor",
+            messageFormat: "the message from {0}",
             category: "the category",
             DiagnosticSeverity.Info,
             isEnabledByDefault: true);
@@ -32,7 +32,7 @@ public static class HelloWorld
             new LinePositionSpan(
                 new LinePosition(1, 2),
                 new LinePosition(3, 4)));
-        var diagnostic = Diagnostic.Create(descriptor, location);
+        var diagnostic = Diagnostic.Create(descriptor, location, "hello world generator");
         context.ReportDiagnostic(diagnostic);
     }
 

--- a/src/Tests/SampleTest.Run.00.verified.txt
+++ b/src/Tests/SampleTest.Run.00.verified.txt
@@ -6,7 +6,8 @@
       Severity: Info,
       WarningLevel: 1,
       Location: theFile: (1,2)-(3,4),
-      MessageFormat: the descriptor,
+      MessageFormat: the message from {0},
+      Message: the message from hello world generator,
       Category: the category
     }
   ]

--- a/src/Verify.SourceGenerators/Converters/DiagnosticConverter.cs
+++ b/src/Verify.SourceGenerators/Converters/DiagnosticConverter.cs
@@ -40,6 +40,9 @@ class DiagnosticConverter :
 
         writer.WritePropertyName("MessageFormat");
         writer.WriteValue(value.Descriptor.MessageFormat.ToString());
+        
+        writer.WritePropertyName("Message");
+        writer.WriteValue(value.GetMessage());
 
         writer.WritePropertyName("Category");
         writer.WriteValue(value.Descriptor.Category);


### PR DESCRIPTION
Only the message format is included in the `DiagnosticConverter`, so message arguments passed during construction are not verified. 