### PR TITLE
feat: Added automatic delivery of ModuleInitializer.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,22 +15,27 @@ Install one of the Verify [testing framework adapters](https://github.com/verify
 
 ## Initialize
 
-Call `VerifySourceGenerators.Enable()` once at assembly load time.
-
+The package requires a call to `VerifySourceGenerators.Enable()` once 
+at assembly load time and automatically adds a file with the following content:
 ```cs
-using System.Runtime.CompilerServices;
-using VerifyTests;
-
-public static class ModuleInitializer
+namespace VerifyTests
 {
-    [ModuleInitializer]
-    public static void Init()
+    public static class ModuleInitializer
     {
-        VerifySourceGenerators.Enable();
+        [global::System.Runtime.CompilerServices.ModuleInitializer]
+        public static void Initialize()
+        {
+            global::VerifyTests.VerifySourceGenerators.Enable();
+        }
     }
 }
 ```
-
+To disable this behavior and do it manually, use:
+```xml
+  <PropertyGroup>
+    <Verify_AddModuleInitializer>false</Verify_AddModuleInitializer>
+  </PropertyGroup>
+```
 
 ## Generator
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649</NoWarn>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <PackageTags>Source Generator, Verify</PackageTags>
     <Description>Extends Verify (https://github.com/VerifyTests/Verify) to allow verification of C# Source Generators.</Description>

--- a/src/Verify.SourceGenerators/Verify.SourceGenerators.csproj
+++ b/src/Verify.SourceGenerators/Verify.SourceGenerators.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" Condition="$(Configuration) == 'Release'" />
-    <Content Include="build\Verify.SourceGenerators.targets" PackagePath="build\Verify.SourceGenerators.targets" />
+    <Content Include="build\*.*" PackagePath="build" />
+    <Compile Remove="build\*.cs" />
   </ItemGroup>
 </Project>

--- a/src/Verify.SourceGenerators/build/ModuleInitializer.cs
+++ b/src/Verify.SourceGenerators/build/ModuleInitializer.cs
@@ -1,0 +1,11 @@
+﻿namespace VerifyTests
+{
+    public static class ModuleInitializer
+    {
+        [global::System.Runtime.CompilerServices.ModuleInitializer]
+        public static void Initialize()
+        {
+            global::VerifyTests.VerifySourceGenerators.Enable();
+        }
+    }
+}

--- a/src/Verify.SourceGenerators/build/Verify.SourceGenerators.targets
+++ b/src/Verify.SourceGenerators/build/Verify.SourceGenerators.targets
@@ -8,4 +8,12 @@
       <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
     </None>
   </ItemGroup>
+
+  <PropertyGroup>
+    <Verify_AddModuleInitializer>true</Verify_AddModuleInitializer>
+  </PropertyGroup>
+  
+  <ItemGroup Condition="$(Verify_AddModuleInitializer)">
+    <Compile Include="$(MSBuildThisFileDirectory)ModuleInitializer.cs" Visible="false" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Added automatic delivery of the ModuleInitializer because this is the default behavior of the package and it won't work without it. Also, the user can disable this behavior if desired or necessary.
I removed netcoreapp3.1 because it is no longer supported and didn't work with `<Compile Remove="build\*.cs" />`