### PR TITLE
feat: added `IgnoreGeneratedResultInstance`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -223,6 +223,31 @@ public Task ScrubLines()
 <!-- endSnippet -->
  
 
+  ## Ignoring Files
+
+To ignore specific source text use `IgnoreGeneratedResultInstance`. This uses an expression of type `Func<GeneratedSourceResult, bool>` to determine which outputs are ignored.
+
+For example to ignore files with the name `helper` or that contain the text `static void SayHello()`:
+
+<!-- snippet: IgnoreFile -->
+<a id='snippet-IgnoreFile'></a>
+```cs
+[Fact]
+public Task IgnoreFile()
+{
+    var driver = GeneratorDriver();
+
+    return Verify(driver)
+        .IgnoreGeneratedResultInstance(x => x.HintName.Contains("helper"))
+        .IgnoreGeneratedResultInstance(x => x.SourceText
+            .ToString()
+            .Contains("static void SayHello()"));
+}
+```
+<sup><a href='/src/Tests/IgnoreTest.cs#L6-L18' title='Snippet source file'>snippet source</a> | <a href='#snippet-IgnoreFile' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+
 ## Notes:
 
  * [Source Generators Cookbook / Testing](https://github.com/dotnet/roslyn/blob/main/docs/features/source-generators.cookbook.md#unit-testing-of-generators)

--- a/src/Tests/IgnoreTest.IgnoreFile.verified.txt
+++ b/src/Tests/IgnoreTest.IgnoreFile.verified.txt
@@ -1,0 +1,14 @@
+﻿{
+  Diagnostics: [
+    {
+      Id: theId,
+      Title: the title,
+      Severity: Info,
+      WarningLevel: 1,
+      Location: theFile: (1,2)-(3,4),
+      MessageFormat: the message from {0},
+      Message: the message from hello world generator,
+      Category: the category
+    }
+  ]
+}

--- a/src/Tests/IgnoreTest.SettingsIgnoreFile.verified.txt
+++ b/src/Tests/IgnoreTest.SettingsIgnoreFile.verified.txt
@@ -1,0 +1,14 @@
+﻿{
+  Diagnostics: [
+    {
+      Id: theId,
+      Title: the title,
+      Severity: Info,
+      WarningLevel: 1,
+      Location: theFile: (1,2)-(3,4),
+      MessageFormat: the message from {0},
+      Message: the message from hello world generator,
+      Category: the category
+    }
+  ]
+}

--- a/src/Tests/IgnoreTest.cs
+++ b/src/Tests/IgnoreTest.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+public class IgnoreTest
+{
+    #region IgnoreFile
+    [Fact]
+    public Task IgnoreFile()
+    {
+        var driver = GeneratorDriver();
+
+        return Verify(driver)
+            .IgnoreGeneratedResultInstance(x => x.HintName.Contains("helper"))
+            .IgnoreGeneratedResultInstance(x => x.SourceText
+                .ToString()
+                .Contains("static void SayHello()"));
+    }
+    #endregion
+
+    [Fact]
+    public Task SettingsIgnoreFile()
+    {
+        var driver = GeneratorDriver();
+        var settings = new VerifySettings();
+        settings.IgnoreGeneratedResultInstance(x => x.HintName.Contains("helper"));
+        settings.IgnoreGeneratedResultInstance(x => x.SourceText
+            .ToString()
+            .Contains("static void SayHello()"));
+
+        return Verify(driver, settings);
+    }
+
+    static GeneratorDriver GeneratorDriver()
+    {
+        var compilation = CSharpCompilation.Create("name");
+        var generator = new HelloWorldGenerator();
+
+        var driver = CSharpGeneratorDriver.Create(generator);
+        return driver.RunGenerators(compilation);
+    }
+}

--- a/src/Verify.SourceGenerators/VerifySourceGenerators.cs
+++ b/src/Verify.SourceGenerators/VerifySourceGenerators.cs
@@ -34,6 +34,9 @@ public static class VerifySourceGenerators
     {
         var exceptions = new List<Exception>();
         var targets = new List<Target>();
+        context.TryGetValue(VerifySourceGeneratorsExtensions.IgnoreContextName, out var ignoreResultsObj);
+        var ignoreResults = ignoreResultsObj as List<Func<GeneratedSourceResult, bool>> ?? new();
+
         foreach (var result in target.Results)
         {
             if (result.Exception != null)
@@ -42,6 +45,7 @@ public static class VerifySourceGenerators
             }
 
             var collection = result.GeneratedSources
+                .Where(source => !ignoreResults.Any(fn => fn(source)))
                 .OrderBy(_ => _.HintName)
                 .Select(SourceToTarget);
             targets.AddRange(collection);

--- a/src/Verify.SourceGenerators/VerifySourceGeneratorsExtensions.cs
+++ b/src/Verify.SourceGenerators/VerifySourceGeneratorsExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace VerifyTests;
+
+public static class VerifySourceGeneratorsExtensions
+{
+    internal const string IgnoreContextName = $"{nameof(VerifySourceGenerators)}.{nameof(IgnoreGeneratedResultInstance)}";
+
+    public static SettingsTask IgnoreGeneratedResultInstance(this SettingsTask settingsTask, Func<GeneratedSourceResult, bool> shouldIgnore)
+    {
+        settingsTask.CurrentSettings.IgnoreGeneratedResultInstance(shouldIgnore);
+        return settingsTask;
+    }
+
+    public static void IgnoreGeneratedResultInstance(this VerifySettings verifySettings, Func<GeneratedSourceResult, bool> shouldIgnore)
+    {
+        if (!verifySettings.Context.TryGetValue(IgnoreContextName, out var value))
+        {
+            value = new List<Func<GeneratedSourceResult, bool>>();
+            verifySettings.Context.Add(IgnoreContextName, value);
+        }
+
+        if (value is not List<Func<GeneratedSourceResult, bool>> ignoreList)
+        {
+            throw new($"Unexpected value in {nameof(verifySettings.Context)}, type is not {nameof(List<Func<GeneratedSourceResult, bool>>)}");
+        }
+
+        ignoreList.Add(shouldIgnore);
+    }
+}


### PR DESCRIPTION
Added the extension method `IgnoreGeneratedResultInstance`. Uses `VerifySettings.Context` to store ignore expressions.

- Not sure about the name `IgnoreGeneratedResultInstance` perhaps `IgnoreGeneratedResult` is better.
- Added `IgnoreTest` and updated the readme

See #67