### PR TITLE
Simplify DiagnosticConverter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,19 +162,23 @@ An info file containing all metadata about the current state. eg any Diagnostics
 {
   Diagnostics: [
     {
-      Id: theId,
-      Title: the title,
+      Location: dir\theFile.cs: (1,2)-(3,4),
+      Message: the message from hello world generator,
       Severity: Info,
       WarningLevel: 1,
-      Location: dir\theFile.cs: (1,2)-(3,4),
-      MessageFormat: the message from {0},
-      Message: the message from hello world generator,
-      Category: the category
+      Descriptor: {
+        Id: theId,
+        Title: the title,
+        MessageFormat: the message from {0},
+        Category: the category,
+        DefaultSeverity: Info,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }
 ```
-<sup><a href='/src/Tests/SampleTest.Driver.verified.txt#L1-L14' title='Snippet source file'>snippet source</a> | <a href='#snippet-SampleTest.Driver.verified.txt' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/SampleTest.Driver.verified.txt#L1-L18' title='Snippet source file'>snippet source</a> | <a href='#snippet-SampleTest.Driver.verified.txt' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/Tests/IgnoreTest.IgnoreFile.verified.txt
+++ b/src/Tests/IgnoreTest.IgnoreFile.verified.txt
@@ -1,14 +1,18 @@
 ﻿{
   Diagnostics: [
     {
-      Id: theId,
-      Title: the title,
+      Location: dir\theFile.cs: (1,2)-(3,4),
+      Message: the message from hello world generator,
       Severity: Info,
       WarningLevel: 1,
-      Location: dir\theFile.cs: (1,2)-(3,4),
-      MessageFormat: the message from {0},
-      Message: the message from hello world generator,
-      Category: the category
+      Descriptor: {
+        Id: theId,
+        Title: the title,
+        MessageFormat: the message from {0},
+        Category: the category,
+        DefaultSeverity: Info,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/src/Tests/IgnoreTest.SettingsIgnoreFile.verified.txt
+++ b/src/Tests/IgnoreTest.SettingsIgnoreFile.verified.txt
@@ -1,14 +1,18 @@
 ﻿{
   Diagnostics: [
     {
-      Id: theId,
-      Title: the title,
+      Location: dir\theFile.cs: (1,2)-(3,4),
+      Message: the message from hello world generator,
       Severity: Info,
       WarningLevel: 1,
-      Location: dir\theFile.cs: (1,2)-(3,4),
-      MessageFormat: the message from {0},
-      Message: the message from hello world generator,
-      Category: the category
+      Descriptor: {
+        Id: theId,
+        Title: the title,
+        MessageFormat: the message from {0},
+        Category: the category,
+        DefaultSeverity: Info,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/src/Tests/SampleTest.Driver.verified.txt
+++ b/src/Tests/SampleTest.Driver.verified.txt
@@ -1,14 +1,18 @@
 ﻿{
   Diagnostics: [
     {
-      Id: theId,
-      Title: the title,
+      Location: dir\theFile.cs: (1,2)-(3,4),
+      Message: the message from hello world generator,
       Severity: Info,
       WarningLevel: 1,
-      Location: dir\theFile.cs: (1,2)-(3,4),
-      MessageFormat: the message from {0},
-      Message: the message from hello world generator,
-      Category: the category
+      Descriptor: {
+        Id: theId,
+        Title: the title,
+        MessageFormat: the message from {0},
+        Category: the category,
+        DefaultSeverity: Info,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/src/Tests/SampleTest.RunResult.verified.txt
+++ b/src/Tests/SampleTest.RunResult.verified.txt
@@ -27,14 +27,18 @@ public static class HelloWorld
   ],
   Diagnostics: [
     {
-      Id: theId,
-      Title: the title,
+      Location: dir\theFile.cs: (1,2)-(3,4),
+      Message: the message from hello world generator,
       Severity: Info,
       WarningLevel: 1,
-      Location: dir\theFile.cs: (1,2)-(3,4),
-      MessageFormat: the message from {0},
-      Message: the message from hello world generator,
-      Category: the category
+      Descriptor: {
+        Id: theId,
+        Title: the title,
+        MessageFormat: the message from {0},
+        Category: the category,
+        DefaultSeverity: Info,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/src/Tests/SampleTest.RunResults.verified.txt
+++ b/src/Tests/SampleTest.RunResults.verified.txt
@@ -1,14 +1,18 @@
 ﻿{
   Diagnostics: [
     {
-      Id: theId,
-      Title: the title,
+      Location: dir\theFile.cs: (1,2)-(3,4),
+      Message: the message from hello world generator,
       Severity: Info,
       WarningLevel: 1,
-      Location: dir\theFile.cs: (1,2)-(3,4),
-      MessageFormat: the message from {0},
-      Message: the message from hello world generator,
-      Category: the category
+      Descriptor: {
+        Id: theId,
+        Title: the title,
+        MessageFormat: the message from {0},
+        Category: the category,
+        DefaultSeverity: Info,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/src/Tests/SampleVbTest.Driver.verified.txt
+++ b/src/Tests/SampleVbTest.Driver.verified.txt
@@ -1,14 +1,18 @@
 ﻿{
   Diagnostics: [
     {
-      Id: theId,
-      Title: the title,
+      Location: dir\theFile.vb: (1,2)-(3,4),
+      Message: the message from hello world generator,
       Severity: Info,
       WarningLevel: 1,
-      Location: dir\theFile.vb: (1,2)-(3,4),
-      MessageFormat: the message from {0},
-      Message: the message from hello world generator,
-      Category: the category
+      Descriptor: {
+        Id: theId,
+        Title: the title,
+        MessageFormat: the message from {0},
+        Category: the category,
+        DefaultSeverity: Info,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/src/Tests/SampleVbTest.DriverWithoutLocation.verified.txt
+++ b/src/Tests/SampleVbTest.DriverWithoutLocation.verified.txt
@@ -1,13 +1,17 @@
 ﻿{
   Diagnostics: [
     {
-      Id: theId,
-      Title: the title,
+      Message: the message from hello world generator,
       Severity: Info,
       WarningLevel: 1,
-      MessageFormat: the message from {0},
-      Message: the message from hello world generator,
-      Category: the category
+      Descriptor: {
+        Id: theId,
+        Title: the title,
+        MessageFormat: the message from {0},
+        Category: the category,
+        DefaultSeverity: Info,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/src/Tests/SampleVbTest.RunResult.verified.txt
+++ b/src/Tests/SampleVbTest.RunResult.verified.txt
@@ -24,14 +24,18 @@ End Module
   ],
   Diagnostics: [
     {
-      Id: theId,
-      Title: the title,
+      Location: dir\theFile.vb: (1,2)-(3,4),
+      Message: the message from hello world generator,
       Severity: Info,
       WarningLevel: 1,
-      Location: dir\theFile.vb: (1,2)-(3,4),
-      MessageFormat: the message from {0},
-      Message: the message from hello world generator,
-      Category: the category
+      Descriptor: {
+        Id: theId,
+        Title: the title,
+        MessageFormat: the message from {0},
+        Category: the category,
+        DefaultSeverity: Info,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/src/Tests/SampleVbTest.RunResultWithoutLocation.verified.txt
+++ b/src/Tests/SampleVbTest.RunResultWithoutLocation.verified.txt
@@ -24,13 +24,17 @@ End Module
   ],
   Diagnostics: [
     {
-      Id: theId,
-      Title: the title,
+      Message: the message from hello world generator,
       Severity: Info,
       WarningLevel: 1,
-      MessageFormat: the message from {0},
-      Message: the message from hello world generator,
-      Category: the category
+      Descriptor: {
+        Id: theId,
+        Title: the title,
+        MessageFormat: the message from {0},
+        Category: the category,
+        DefaultSeverity: Info,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/src/Tests/SampleVbTest.RunResults.verified.txt
+++ b/src/Tests/SampleVbTest.RunResults.verified.txt
@@ -1,14 +1,18 @@
 ﻿{
   Diagnostics: [
     {
-      Id: theId,
-      Title: the title,
+      Location: dir\theFile.vb: (1,2)-(3,4),
+      Message: the message from hello world generator,
       Severity: Info,
       WarningLevel: 1,
-      Location: dir\theFile.vb: (1,2)-(3,4),
-      MessageFormat: the message from {0},
-      Message: the message from hello world generator,
-      Category: the category
+      Descriptor: {
+        Id: theId,
+        Title: the title,
+        MessageFormat: the message from {0},
+        Category: the category,
+        DefaultSeverity: Info,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/src/Tests/SampleVbTest.RunResultsWithoutLocation.verified.txt
+++ b/src/Tests/SampleVbTest.RunResultsWithoutLocation.verified.txt
@@ -1,13 +1,17 @@
 ﻿{
   Diagnostics: [
     {
-      Id: theId,
-      Title: the title,
+      Message: the message from hello world generator,
       Severity: Info,
       WarningLevel: 1,
-      MessageFormat: the message from {0},
-      Message: the message from hello world generator,
-      Category: the category
+      Descriptor: {
+        Id: theId,
+        Title: the title,
+        MessageFormat: the message from {0},
+        Category: the category,
+        DefaultSeverity: Info,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/src/Tests/ScrubTest.ScrubLines.verified.txt
+++ b/src/Tests/ScrubTest.ScrubLines.verified.txt
@@ -1,14 +1,18 @@
 ﻿{
   Diagnostics: [
     {
-      Id: theId,
-      Title: the title,
+      Location: dir\theFile.cs: (1,2)-(3,4),
+      Message: the message from hello world generator,
       Severity: Info,
       WarningLevel: 1,
-      Location: dir\theFile.cs: (1,2)-(3,4),
-      MessageFormat: the message from {0},
-      Message: the message from hello world generator,
-      Category: the category
+      Descriptor: {
+        Id: theId,
+        Title: the title,
+        MessageFormat: the message from {0},
+        Category: the category,
+        DefaultSeverity: Info,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/src/Verify.SourceGenerators/Converters/DiagnosticConverter.cs
+++ b/src/Verify.SourceGenerators/Converters/DiagnosticConverter.cs
@@ -4,31 +4,17 @@
     public override void Write(VerifyJsonWriter writer, Diagnostic value)
     {
         writer.WriteStartObject();
-        writer.WriteMember(value, value.Id, "Id");
-        var descriptor = value.Descriptor;
-        writer.WriteMember(value, descriptor.Title, "Title");
-        writer.WriteMember(value, value.Severity, "Severity");
-        writer.WriteMember(value, value.WarningLevel, "WarningLevel");
         if (value.Location != Location.None)
         {
             writer.WriteMember(value, value.Location, "Location");
         }
-        var description = descriptor.Description.ToString(CultureInfo.InvariantCulture);
-        if (!string.IsNullOrWhiteSpace(description))
-        {
-            writer.WriteMember(value, description, "Description");
-        }
-
-        var help = descriptor.HelpLinkUri;
-        if (!string.IsNullOrWhiteSpace(help))
-        {
-            writer.WriteMember(value, help, "HelpLink");
-        }
-
-        writer.WriteMember(value, descriptor.MessageFormat, "MessageFormat");
         writer.WriteMember(value, value.GetMessage(CultureInfo.InvariantCulture), "Message");
-        writer.WriteMember(value, descriptor.Category, "Category");
-        writer.WriteMember(value, descriptor.CustomTags, "CustomTags");
+        writer.WriteMember(value, value.Severity, "Severity");
+        if (value.WarningLevel != 0)
+        {
+            writer.WriteMember(value, value.WarningLevel, "WarningLevel");
+        }
+        writer.WriteMember(value, value.Descriptor, "Descriptor");
         writer.WriteEndObject();
     }
 }


### PR DESCRIPTION
Only a few fields on Diagnostic are its own, and the rest can be delegated to the existing DiagnosticDescriptor renderer.

This both simplifies the implementation, and makes Diagnostic's own output have clearer separation between own and "inherited" information.