### PR TITLE
Preserve stack trace of exception thrown by source generator.

### DIFF
--- a/src/Verify.SourceGenerators/VerifySourceGenerators.cs
+++ b/src/Verify.SourceGenerators/VerifySourceGenerators.cs
@@ -1,4 +1,6 @@
-﻿namespace VerifyTests;
+﻿using System.Runtime.ExceptionServices;
+
+namespace VerifyTests;
 
 public static class VerifySourceGenerators
 {
@@ -52,7 +54,7 @@ public static class VerifySourceGenerators
 
         if (exceptions.Count == 1)
         {
-            throw exceptions.First();
+            ExceptionDispatchInfo.Capture(exceptions.First()).Throw();
         }
 
         if (exceptions.Count > 1)


### PR DESCRIPTION
Hello,

When debugging my source generator, I found it more useful to have the original stack trace.

Thank you
